### PR TITLE
Add Analytics from Vercel

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@shikijs/transformers": "^1.16.3",
     "@types/react": "^18.3.5",
     "@types/react-dom": "^18.3.0",
+    "@vercel/analytics": "^1.4.1",
     "astro": "^4.11.3",
     "astro-embed": "^0.7.4",
     "astro-icon": "^1.1.1",

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -2,6 +2,7 @@
 import Footer from '@/components/Footer.astro'
 import Head from '@/components/Head.astro'
 import Header from '@/components/Header.astro'
+import Analyitcs from '@vercel/analytics/astro'
 import { SITE } from '@/consts'
 
 type Props = {
@@ -34,5 +35,7 @@ const { title, description, image } = Astro.props
     </div>
     <!-- have to use this for twitter embeds -->
     <script async src="https://platform.twitter.com/widgets.js"></script>
+    <!-- Vercel Analytics -->
+    <Analyitcs />
   </body>
 </html>


### PR DESCRIPTION
The website is deployed through Vercel, and they offer free analytics to small websites, like mine.
This would be useful to help gauge what posts or VODs are the most popular.

Obviously it wouldn't work for people with adblock (most people), but still.