### PR TITLE
Add Basic Chat Replay Functionality

### DIFF
--- a/src/components/ChatReplay.tsx
+++ b/src/components/ChatReplay.tsx
@@ -1,0 +1,156 @@
+import { useEffect, useRef, useState } from 'react'
+import { buttonVariants } from './ui/button'
+
+interface ChatComment {
+  _id: string
+  created_at: string
+  content_offset_seconds: number
+  commenter: {
+    display_name: string
+    name: string
+    logo?: string
+  }
+  message: {
+    body: string
+    user_color?: string
+    user_badges?: Array<{
+      _id: string
+      version: string
+    }>
+  }
+}
+
+interface ChatData {
+  comments: ChatComment[]
+  video: {
+    title: string
+    created_at: string
+    length: number
+  }
+}
+
+interface ChatReplayProps {
+  chatReplayURL: string
+  youtubeId: string | undefined
+}
+
+export default function ChatReplay({ chatReplayURL, youtubeId }: ChatReplayProps) {
+  const [comments, setComments] = useState<ChatComment[]>([])
+  const [visibleComments, setVisibleComments] = useState<ChatComment[]>([])
+  const [currentTime, setCurrentTime] = useState(0)
+  const [userScrolled, setUserScrolled] = useState(false)
+  const chatContainerRef = useRef<HTMLDivElement>(null)
+  const playerRef = useRef<any>(null)
+  const MAX_VISIBLE_MESSAGES = 200
+
+  // Load chat messages
+  useEffect(() => {
+    const fetchComments = async () => {
+      try {
+        const response = await fetch(chatReplayURL)
+        const data: ChatData = await response.json()
+        setComments(data.comments.sort((a, b) => a.content_offset_seconds - b.content_offset_seconds))
+      } catch (error) {
+        console.error('Error loading chat messages:', error)
+      }
+    }
+    fetchComments()
+  }, [chatReplayURL])
+
+  // Initialize YouTube Player API
+  useEffect(() => {
+    const tag = document.createElement('script')
+    tag.src = 'https://www.youtube.com/iframe_api'
+    const firstScriptTag = document.getElementsByTagName('script')[0]
+    firstScriptTag.parentNode?.insertBefore(tag, firstScriptTag)
+
+    // @ts-ignore
+    window.onYouTubeIframeAPIReady = () => {
+      // @ts-ignore
+      playerRef.current = new YT.Player(`youtube-player-${youtubeId}`, {
+        events: {
+          onStateChange: (event: any) => {
+            // Update currentTime when video is playing
+            if (event.data === 1) { // Playing
+              const updateTime = () => {
+                if (playerRef.current) {
+                  setCurrentTime(playerRef.current.getCurrentTime())
+                  requestAnimationFrame(updateTime)
+                }
+              }
+              updateTime()
+            }
+          }
+        }
+      })
+    }
+
+    return () => {
+      if (playerRef.current) {
+        playerRef.current.destroy()
+      }
+    }
+  }, [youtubeId])
+
+  // Update visible messages based on current time
+  useEffect(() => {
+    const visibleComments = comments
+      .filter(comment => comment.content_offset_seconds <= currentTime)
+      // Take the last MAX_VISIBLE_MESSAGES messages
+      .slice(-MAX_VISIBLE_MESSAGES)
+    setVisibleComments(visibleComments)
+
+    // Auto-scroll to bottom only if user hasn't scrolled up
+    if (chatContainerRef.current && !userScrolled) {
+      chatContainerRef.current.scrollTop = chatContainerRef.current.scrollHeight
+    }
+  }, [currentTime, comments, userScrolled])
+
+  // Handle scroll events
+  const handleScroll = () => {
+    if (!chatContainerRef.current) return
+
+    const { scrollTop, scrollHeight, clientHeight } = chatContainerRef.current
+    const isAtBottom = scrollHeight - scrollTop - clientHeight < 5
+
+    // Update userScrolled state based on scroll position
+    setUserScrolled(!isAtBottom)
+  }
+
+  return (
+    <div className="bg-card h-4/6 lg:h-full rounded-lg border">
+      <div className="p-3 h-[60px] border-b flex justify-between items-center">
+        <h3 className="font-semibold">Chat Replay</h3>
+        {userScrolled && (
+          <button
+            className={buttonVariants({ variant: 'outline', size: 'sm' })}
+            onClick={() => {
+              if (chatContainerRef.current) {
+                chatContainerRef.current.scrollTop = chatContainerRef.current.scrollHeight
+              }
+            }}
+          >
+            Scrolling Paused
+          </button>
+      )}
+      </div>
+      <div 
+        ref={chatContainerRef}
+        className="h-[calc(100%-60px)] overflow-y-auto p-4 space-y-2"
+        onScroll={handleScroll}
+      >
+        {visibleComments.map((comment) => (
+          <div key={comment._id} className="leading-tight text-sm break-words">
+            <span 
+              className="font-semibold"
+              style={{ color: comment.message.user_color || 'inherit' }}
+            >
+              {comment.commenter.display_name}
+            </span>{': '}
+            <span>{comment.message.body}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -23,7 +23,7 @@ export const SITE: Site = {
   NUM_POSTS_ON_HOMEPAGE: 3,
   NUM_PROJECTS_ON_HOMEPAGE: 4,
   POSTS_PER_PAGE: 8,
-  VODS_PER_PAGE: 9,
+  VODS_PER_PAGE: 15,
   SITEURL: 'https://ltwilson.tv',
   TWITCH_USER_ID: 194814599
 }

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -7,6 +7,7 @@ export type Site = {
   POSTS_PER_PAGE: number
   VODS_PER_PAGE: number
   SITEURL: string
+  TWITCH_USER_ID: number
 }
 
 export type Link = {
@@ -24,6 +25,7 @@ export const SITE: Site = {
   POSTS_PER_PAGE: 8,
   VODS_PER_PAGE: 9,
   SITEURL: 'https://ltwilson.tv',
+  TWITCH_USER_ID: 194814599
 }
 
 export const NAV_LINKS: Link[] = [

--- a/src/content/vods/2025/1/3.md
+++ b/src/content/vods/2025/1/3.md
@@ -1,0 +1,10 @@
+---
+title: "Wilson plays Super Mikurio 64?"
+streamDate: 1-3-2025
+game: "Super Mario 64"
+gameCoverURL: "https://images.igdb.com/igdb/image/upload/t_cover_big/co721v.webp"
+vodUrl: "https://www.youtube.com/watch?v=dYrfIRmufFQ"
+thumbnail: "https://img.youtube.com/vi/dYrfIRmufFQ/maxresdefault.jpg"
+duration: "3:24:15"
+chatReplayURL: "https://gist.githubusercontent.com/TheLtWilson/9e173c8913510a7c92d18889f57550d1/raw/f4e17271e28a0f238f8547937336dcef55e2a934/1-3-25.json"
+---

--- a/src/layouts/MinimalLayout.astro
+++ b/src/layouts/MinimalLayout.astro
@@ -1,0 +1,37 @@
+---
+import Head from '@/components/Head.astro'
+import Analyitcs from '@vercel/analytics/astro'
+import { SITE } from '@/consts'
+
+type Props = {
+  title: string
+  description: string
+  image?: string
+}
+
+const { title, description, image } = Astro.props
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <Head
+      title={`${title} - ${SITE.TITLE}`}
+      description={description}
+      image={image}
+    />
+  </head>
+  <body>
+    <div
+      class="box-border flex h-fit min-h-screen flex-col gap-y-6 font-sans antialiased"
+    >
+      <main class="flex-grow">
+        <slot />
+      </main>
+    </div>
+    <!-- have to use this for twitter embeds -->
+    <script async src="https://platform.twitter.com/widgets.js"></script>
+    <!-- Vercel Analytics -->
+    <Analyitcs />
+  </body>
+</html>

--- a/src/pages/vods/index.astro
+++ b/src/pages/vods/index.astro
@@ -53,6 +53,7 @@ const vodsByGame = sortedVods.reduce(
         items={[{ label: 'VODs', icon: 'lucide:film' }]} 
       />
     </div>
+    <h2 class="text-3xl font-bold mb-4">Latest Stream</h2>
     {latestVod && (
       <section class="mb-16">
         <VodCard vod={latestVod} featured={true} />

--- a/src/pages/vods/watch/[...slug].astro
+++ b/src/pages/vods/watch/[...slug].astro
@@ -43,13 +43,14 @@ const youtubeId = getYouTubeVideoID(vod.data.vodUrl)
     </div>
 
     <!-- Content Area -->
-    <div class="relative flex flex-1 flex-col md:flex-row">
+    <div class="relative flex flex-1 flex-col md:flex-row overflow-hidden">
       <!-- Video Player -->
       <div class="relative flex-1">
         <div class="relative h-full w-full">
           <iframe
+            id={`youtube-player-${youtubeId}`}
             class="absolute left-0 top-0 h-full w-full"
-            src={`https://www.youtube.com/embed/${youtubeId}`}
+            src={`https://www.youtube.com/embed/${youtubeId}?enablejsapi=1&origin=${Astro.url.origin}&autoplay=1`}
             title={vod.data.title}
             allow="autoplay; encrypted-media; picture-in-picture"
             allowfullscreen
@@ -60,7 +61,7 @@ const youtubeId = getYouTubeVideoID(vod.data.vodUrl)
 
       <!-- Chat Replay -->
       {vod.data.chatReplayURL && (
-        <div class="h-[60vh] border-t md:h-auto md:w-80 md:border-l md:border-t-0 bg-muted/30">
+        <div class="h-[60vh] md:h-auto md:w-80 border-t md:border-l md:border-t-0 bg-muted/30 overflow-hidden">
           <ChatReplay client:load chatReplayURL={vod.data.chatReplayURL} youtubeId={youtubeId} />
         </div>
       )}

--- a/src/pages/vods/watch/[...slug].astro
+++ b/src/pages/vods/watch/[...slug].astro
@@ -47,15 +47,10 @@ const youtubeId = getYouTubeVideoID(vod.data.vodUrl)
       <!-- Video Player -->
       <div class="relative flex-1">
         <div class="relative h-full w-full">
-          <iframe
+          <div
             id={`youtube-player-${youtubeId}`}
             class="absolute left-0 top-0 h-full w-full"
-            src={`https://www.youtube.com/embed/${youtubeId}?enablejsapi=1&origin=${Astro.url.origin}&autoplay=1`}
-            title={vod.data.title}
-            allow="autoplay; encrypted-media; picture-in-picture"
-            allowfullscreen
-          >
-          </iframe>
+          ></div>
         </div>
       </div>
 

--- a/src/pages/vods/watch/[...slug].astro
+++ b/src/pages/vods/watch/[...slug].astro
@@ -1,6 +1,7 @@
 ---
 import Breadcrumbs from '@/components/Breadcrumbs.astro'
 import { Card } from '@/components/ui/card'
+import ChatReplay from '@/components/ChatReplay'
 import Layout from '@/layouts/Layout.astro'
 import { getYouTubeVideoID } from '@/lib/utils'
 import { getCollection } from 'astro:content'
@@ -14,6 +15,7 @@ export async function getStaticPaths() {
 }
 
 const { vod } = Astro.props
+const { Content } = await vod.render()
 const youtubeId = getYouTubeVideoID(vod.data.vodUrl)
 ---
 
@@ -29,18 +31,20 @@ const youtubeId = getYouTubeVideoID(vod.data.vodUrl)
     </div>
 
     <div class="mx-auto">
-      <!-- YouTube Embed -->
-      <div class="relative mb-6 h-0 overflow-hidden rounded-lg pb-[56.25%]">
-        <iframe
-          class="absolute left-0 top-0 h-full w-full"
-          src={`https://www.youtube.com/embed/${youtubeId}`}
-          title={vod.data.title}
-          frameborder="0"
-          allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-          allowfullscreen
-        >
-        </iframe>
-      </div>
+      <div class={vod.data.chatReplayURL ? "grid grid-cols-1 lg:grid-cols-[1fr,300px] gap-6" : ""}>
+        <div>
+          <!-- YouTube Embed -->
+          <div class="relative mb-6 h-0 overflow-hidden rounded-lg pb-[56.25%]">
+            <iframe
+              id={`youtube-player-${youtubeId}`}
+              class="absolute left-0 top-0 h-full w-full"
+              src={`https://www.youtube.com/embed/${youtubeId}?enablejsapi=1&autoplay=1`}
+              title={vod.data.title}
+              allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+              allowfullscreen
+            >
+            </iframe>
+          </div>
 
       <!-- VOD Information -->
       <Card className="flex gap-x-4 p-4">
@@ -81,7 +85,12 @@ const youtubeId = getYouTubeVideoID(vod.data.vodUrl)
             </p>
           </div>
         </div>
-      </Card>
+      </div>
+        {vod.data.chatReplayURL && (
+          <div class="h-[calc(100vh-12rem)] sticky top-24">
+            <ChatReplay client:load chatReplayURL={vod.data.chatReplayURL} youtubeId={youtubeId} />
+          </div>
+        )}
     </div>
   </main>
 </Layout>

--- a/src/pages/vods/watch/[...slug].astro
+++ b/src/pages/vods/watch/[...slug].astro
@@ -47,10 +47,20 @@ const youtubeId = getYouTubeVideoID(vod.data.vodUrl)
       <!-- Video Player -->
       <div class="relative flex-1">
         <div class="relative h-full w-full">
-          <div
-            id={`youtube-player-${youtubeId}`}
+          {vod.data.chatReplayURL ? (
+            <div
+              id={`youtube-player-${youtubeId}`}
+              class="absolute left-0 top-0 h-full w-full"
+            ></div>
+          ) : (
+          <iframe
             class="absolute left-0 top-0 h-full w-full"
-          ></div>
+            src={`https://www.youtube.com/embed/${youtubeId}?enablejsapi=1&origin=${Astro.url.origin}&autoplay=1`}
+            allow="autoplay; encrypted-media; picture-in-picture"
+            allowfullscreen
+          >
+          </iframe>
+          )}
         </div>
       </div>
 

--- a/src/pages/vods/watch/[...slug].astro
+++ b/src/pages/vods/watch/[...slug].astro
@@ -1,10 +1,11 @@
 ---
-import Breadcrumbs from '@/components/Breadcrumbs.astro'
-import { Card } from '@/components/ui/card'
-import ChatReplay from '@/components/ChatReplay'
-import Layout from '@/layouts/Layout.astro'
+import ChatReplay from '@/components/ChatReplay.tsx'
+import MinimalLayout from '@/layouts/MinimalLayout.astro'
+import { Icon } from 'astro-icon/components'
+import { buttonVariants } from '@/components/ui/button'
 import { getYouTubeVideoID } from '@/lib/utils'
 import { getCollection } from 'astro:content'
+import Image from 'astro/components/Image.astro'
 
 export async function getStaticPaths() {
   const vods = await getCollection('vods')
@@ -15,82 +16,54 @@ export async function getStaticPaths() {
 }
 
 const { vod } = Astro.props
-const { Content } = await vod.render()
 const youtubeId = getYouTubeVideoID(vod.data.vodUrl)
 ---
 
-<Layout title={vod.data.title} description={`Stream VOD: ${vod.data.title}`}>
-  <main class="mx-auto max-w-screen-xl px-4 sm:px-6 lg:px-8">
-    <div class="py-4">
-      <Breadcrumbs
-        items={[
-          { href: '/vods', label: 'VODs', icon: 'lucide:film' },
-          { label: vod.data.title, icon: 'lucide:play' },
-        ]}
-      />
-    </div>
-
-    <div class="mx-auto">
-      <div class={vod.data.chatReplayURL ? "grid grid-cols-1 lg:grid-cols-[1fr,300px] gap-6" : ""}>
-        <div>
-          <!-- YouTube Embed -->
-          <div class="relative mb-6 h-0 overflow-hidden rounded-lg pb-[56.25%]">
-            <iframe
-              id={`youtube-player-${youtubeId}`}
-              class="absolute left-0 top-0 h-full w-full"
-              src={`https://www.youtube.com/embed/${youtubeId}?enablejsapi=1&autoplay=1`}
-              title={vod.data.title}
-              allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-              allowfullscreen
-            >
-            </iframe>
-          </div>
-
-      <!-- VOD Information -->
-      <Card className="flex gap-x-4 p-4">
-        <img
+<MinimalLayout title={vod.data.title} description={`Stream VOD: ${vod.data.title}`}>
+  <main class="flex h-screen flex-col">
+    <!-- Top Navigation Bar -->
+    <div class="flex items-center justify-between border-b p-4">
+      <a class={buttonVariants({ variant: 'outline' })} href="/vods">
+        <Icon name="lucide:chevron-left" class="md:mr-2" />
+        <span class="hidden md:inline">VODs</span>
+      </a>
+      <div class="flex items-center text-right gap-4">
+        <div class="max-w-[70vw]">
+          <h1 class="text-lg font-semibold truncate">{vod.data.title}</h1>
+          <p class="text-sm text-muted-foreground truncate">{vod.data.game} • {vod.data.streamDate.toLocaleString('en-US', { month: 'long', day: 'numeric', year: 'numeric' })}</p>
+        </div>
+        <Image
           src={vod.data.gameCoverURL}
           alt={`Game cover for ${vod.data.game}`}
-          class="aspect-[3/4] max-h-24 max-w-20 rounded-lg"
+          width={32}
+          height={32}
+          class="hidden md:block h-12 w-9 rounded"
         />
-        <div>
-          <h3 class="mb-1 text-xl font-semibold md:text-2xl">
-            {vod.data.title}
-          </h3>
-          <div class="text-sm text-muted-foreground">
-            <p>
-              Playing: <span class="font-semibold text-foreground"
-                ><a
-                  href={`/vods/games/${vod.data.game.toLowerCase().replace(/[^a-z0-9]+/g, '-')}`}
-                  class="hover:underline">{vod.data.game}</a
-                ></span
-              >
-            </p>
-            <p>
-              Streamed on: <span class="font-semibold text-foreground"
-                >{
-                  vod.data.streamDate.toLocaleDateString('en-US', {
-                    weekday: 'long',
-                    year: 'numeric',
-                    month: 'long',
-                    day: 'numeric',
-                  })
-                }</span
-              >
-            </p>
-            <p>
-              Duration: <span class="font-semibold text-foreground"
-                >{vod.data.duration}</span
-              >
-            </p>
-          </div>
+      </div>
+    </div>
+
+    <!-- Content Area -->
+    <div class="relative flex flex-1 flex-col md:flex-row">
+      <!-- Video Player -->
+      <div class="relative flex-1">
+        <div class="relative h-full w-full">
+          <iframe
+            class="absolute left-0 top-0 h-full w-full"
+            src={`https://www.youtube.com/embed/${youtubeId}`}
+            title={vod.data.title}
+            allow="autoplay; encrypted-media; picture-in-picture"
+            allowfullscreen
+          >
+          </iframe>
         </div>
       </div>
-        {vod.data.chatReplayURL && (
-          <div class="h-[calc(100vh-12rem)] sticky top-24">
-            <ChatReplay client:load chatReplayURL={vod.data.chatReplayURL} youtubeId={youtubeId} />
-          </div>
-        )}
+
+      <!-- Chat Replay -->
+      {vod.data.chatReplayURL && (
+        <div class="h-[60vh] border-t md:h-auto md:w-80 md:border-l md:border-t-0 bg-muted/30">
+          <ChatReplay client:load chatReplayURL={vod.data.chatReplayURL} youtubeId={youtubeId} />
+        </div>
+      )}
     </div>
   </main>
-</Layout>
+</MinimalLayout>


### PR DESCRIPTION
This pull request includes the following changes:

- Introduces a chat replay for VODs, if available.
- A new "watch mode" experience, that highlights the content and chat to utilize screen space.
- Increases the number of VODs displayed per page at [/vods/all](https://ltwilson.tv/vods/all)

As of right now, the functionality is pretty basic. Chatters have their specific username color, but no badges or emotes are displayed in the replay. I intend to add these features later on.