### PR TITLE
Update Wave Link Key Wrapper to be deprecated.

### DIFF
--- a/src/content/blog/2024/elgato-wave-link-project/index.mdx
+++ b/src/content/blog/2024/elgato-wave-link-project/index.mdx
@@ -7,6 +7,12 @@ image: './thumbnail.webp'
 authors: ['rileywilson']
 ---
 
+```md
+⚠️ NOTICE:
+This project has now been deprecated.
+This post will remain published in case the information is still relevant.
+```
+
 A couple years ago, I upgraded my microphone from a FIFINE T669, to one of Elgato's esteemed Wave:3 microphones. At the time, I simply just wanted a better way to manage audio and the ability to hear myself when using headphones. Elgato's microphone provided a solution to both of these problems, with their Wave Link software. Their software allows you to create virtual audio devices so that you can easily manage different types of audio sources, like a browser, music, games, or the rest of the system. All with the added benefit of having direct integration into the Stream Deck.
 
 Now, while I have my own gripes with Elgato's software - especially as of late. Don't even get me started with how awful the Stream Deck has become with their new website to download plugins,but it's pretty powerful software... ***when it works***.

--- a/src/content/projects/wave-link-key-wrapper/index.md
+++ b/src/content/projects/wave-link-key-wrapper/index.md
@@ -1,6 +1,6 @@
 ---
 name: 'Wave Link Key Wrapper'
-description: "A project that hooks into Elgato's Wave Link software to make audio control easier and more visual, also includes some documentation."
+description: "An archived project that hooks into Elgato's Wave Link software to make audio control easier and more visual, also includes some documentation."
 image: './icon.webp'
 link: 'https://github.com/theltwilson/wave-link-key-wrapper'
 license: 'MIT License'


### PR DESCRIPTION
This modifies both the:

- Project entry for Wave Link Key Wrapper
- The blog post discussing the creation of it.

To show that the project has now been deprecated and is no longer maintained.