### PR TITLE
(feat) Badges and Emotes in Chat Replay

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@radix-ui/react-icons": "^1.3.0",
     "@radix-ui/react-separator": "^1.1.0",
     "@radix-ui/react-slot": "^1.1.0",
+    "@radix-ui/react-tooltip": "^1.1.8",
     "@rehype-pretty/transformers": "^0.13.2",
     "@shikijs/transformers": "^1.16.3",
     "@types/react": "^18.3.5",

--- a/src/components/chat-replay/Badge.tsx
+++ b/src/components/chat-replay/Badge.tsx
@@ -1,0 +1,22 @@
+import { BADGES } from '@/consts';
+import type { BadgeId } from '@/consts';
+
+interface BadgeProps {
+  badgeId: string;
+  version: string;
+}
+
+export function Badge({ badgeId, version }: BadgeProps) {
+  const badge = BADGES[badgeId as BadgeId];
+  
+  if (!badge) return null;
+  
+  return (
+    <img
+      src={badge.imageUrl}
+      alt={badge.title}
+      title={badge.title}
+      className="inline-block h-4 w-4 mr-1"
+    />
+  );
+}

--- a/src/components/chat-replay/Badge.tsx
+++ b/src/components/chat-replay/Badge.tsx
@@ -1,18 +1,32 @@
-import { BADGES } from '@/consts';
-import type { BadgeId } from '@/consts';
-import type { BadgeProps } from './types';
+import { BADGES } from '@/consts'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+  TooltipProvider,
+} from '@/components/ui/tooltip'
+import type { BadgeId } from '@/consts'
+import type { BadgeProps } from './types'
 
 export function Badge({ badgeId, version }: BadgeProps) {
-  const badge = BADGES[badgeId as BadgeId];
-  
-  if (!badge) return null;
-  
+  const badge = BADGES[badgeId as BadgeId]
+
+  if (!badge) return null
+
   return (
-    <img
-      src={badge.imageUrl}
-      alt={badge.title}
-      title={badge.title}
-      className="inline-block h-4 w-4 mr-1"
-    />
-  );
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger>
+          <img
+            src={badge.imageUrl}
+            alt={badge.title}
+            className="mr-1 inline-block h-4 w-4"
+          />
+        </TooltipTrigger>
+        <TooltipContent>
+          {badge.title}
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  )
 }

--- a/src/components/chat-replay/Badge.tsx
+++ b/src/components/chat-replay/Badge.tsx
@@ -1,10 +1,6 @@
 import { BADGES } from '@/consts';
 import type { BadgeId } from '@/consts';
-
-interface BadgeProps {
-  badgeId: string;
-  version: string;
-}
+import type { BadgeProps } from './types';
 
 export function Badge({ badgeId, version }: BadgeProps) {
   const badge = BADGES[badgeId as BadgeId];

--- a/src/components/chat-replay/ChatMessage.tsx
+++ b/src/components/chat-replay/ChatMessage.tsx
@@ -1,0 +1,99 @@
+import { type FC } from 'react';
+import { TwitchEmote } from './TwitchEmote';
+import { SeventvEmote } from './SeventvEmote';
+import type { ChatMessageProps } from './types';
+
+export const ChatMessage: FC<ChatMessageProps> = ({ fragments, emoteData }) => {
+  const processMessage = () => {
+    let result: React.ReactNode[] = [];
+    let currentIndex = 0;
+
+    // First, process Twitch emotes since we have their positions
+    fragments.forEach((fragment, index) => {
+      if (fragment.emoticon) {
+        // Add any text before the emote
+        if (currentIndex < index) {
+          const textContent = fragments
+            .slice(currentIndex, index)
+            .map(f => f.text)
+            .join('');
+          result.push(<span key={`text-${index}`}>{processSevenTvEmotes(textContent, emoteData)}</span>);
+        }
+        // Add the Twitch emote
+        result.push(
+          <TwitchEmote
+            key={`twitch-${fragment.emoticon.emoticon_id}-${index}`}
+            emoteId={fragment.emoticon.emoticon_id}
+            text={fragment.text}
+          />
+        );
+        currentIndex = index + 1;
+      }
+    });
+
+    // Process any remaining text for 7TV emotes
+    if (currentIndex < fragments.length) {
+      const remainingText = fragments
+        .slice(currentIndex)
+        .map(f => f.text)
+        .join('');
+      result.push(<span key="remaining">{processSevenTvEmotes(remainingText, emoteData)}</span>);
+    }
+
+    return result;
+  };
+
+  // Helper function to process text for 7TV emotes
+  const processSevenTvEmotes = (text: string, emoteData: Record<string, { type: 'twitch' | '7tv', id: string }>) => {
+    const result: React.ReactNode[] = [];
+    let currentPosition = 0;
+
+    // Create a regex pattern that matches any of the 7TV emote aliases as complete words
+    const sevenTvEmotes = Object.entries(emoteData)
+      .filter(([_, data]) => data.type === '7tv')
+      .map(([alias]) => alias);
+
+    if (sevenTvEmotes.length === 0) {
+      return text;
+    }
+
+    // Add word boundaries to ensure exact matches only
+    const emotePattern = new RegExp(`\\b(${sevenTvEmotes.map(escapeRegExp).join('|')})\\b`, 'g');
+    let match;
+
+    while ((match = emotePattern.exec(text)) !== null) {
+      // Add any text before the emote
+      if (match.index > currentPosition) {
+        result.push(text.slice(currentPosition, match.index));
+      }
+
+      // Add the 7TV emote
+      const emote = emoteData[match[0]];
+      if (emote && emote.type === '7tv') {
+        result.push(
+          <SeventvEmote
+            key={`7tv-${emote.id}-${match.index}`}
+            emoteId={emote.id}
+            text={match[0]}
+          />
+        );
+      }
+
+      currentPosition = match.index + match[0].length;
+    }
+
+    // Add any remaining text
+    if (currentPosition < text.length) {
+      result.push(text.slice(currentPosition));
+    }
+
+    return result;
+  };
+
+  // Helper function to escape special characters in regex
+  const escapeRegExp = (string: string) => {
+    return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  };
+
+  return <span>{processMessage()}</span>;
+};

--- a/src/components/chat-replay/ChatReplay.tsx
+++ b/src/components/chat-replay/ChatReplay.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from 'react'
 import { buttonVariants } from '@/components/ui/button'
+import { Badge } from './Badge'
 
 interface ChatComment {
   _id: string
@@ -266,6 +267,13 @@ export default function ChatReplay({ chatReplayURL, youtubeId }: ChatReplayProps
               className="font-semibold"
               style={{ color: comment.message.user_color || 'inherit' }}
             >
+              {comment.message.user_badges?.map((badge) => (
+                <Badge
+                  key={`${badge._id}-${badge.version}`}
+                  badgeId={badge._id}
+                  version={badge.version}
+                />
+              ))}
               {comment.commenter.display_name}
             </span>{': '}
             <span>{comment.message.body}</span>

--- a/src/components/chat-replay/ChatReplay.tsx
+++ b/src/components/chat-replay/ChatReplay.tsx
@@ -1,50 +1,9 @@
 import { useEffect, useRef, useState } from 'react'
 import { buttonVariants } from '@/components/ui/button'
 import { Badge } from './Badge'
-
-interface ChatComment {
-  _id: string
-  created_at: string
-  content_offset_seconds: number
-  commenter: {
-    display_name: string
-    name: string
-    logo?: string
-  }
-  message: {
-    body: string
-    user_color?: string
-    user_badges?: Array<{
-      _id: string
-      version: string
-    }>
-  }
-}
-
-interface ChatData {
-  comments: ChatComment[]
-  video: {
-    title: string
-    created_at: string
-    length: number
-  }
-}
-
-interface ChatReplayProps {
-  chatReplayURL: string
-  youtubeId: string | undefined
-}
-
-interface YouTubePlayer {
-  getCurrentTime(): number;
-  getPlayerState(): number;
-  destroy(): void;
-}
-
-interface YouTubeEvent {
-  target: YouTubePlayer;
-  data: number;
-}
+import { ChatMessage } from './ChatMessage'
+import { SITE } from '@/consts'
+import type { ChatComment, ChatData, ChatReplayProps, YouTubePlayer, YouTubeEvent, SevenTvObject, SevenTvEmoteSet } from './types'
 
 declare global {
   interface Window {
@@ -67,11 +26,12 @@ export default function ChatReplay({ chatReplayURL, youtubeId }: ChatReplayProps
   const [visibleComments, setVisibleComments] = useState<ChatComment[]>([])
   const [currentTime, setCurrentTime] = useState(0)
   const [userScrolled, setUserScrolled] = useState(false)
+  const [emoteData, setEmoteData] = useState<Record<string, { type: 'twitch' | '7tv', id: string }>>({});
   const chatContainerRef = useRef<HTMLDivElement>(null)
   const playerRef = useRef<YouTubePlayer | null>(null)
   const MAX_VISIBLE_MESSAGES = 200
 
-  // Load chat messages
+  // Load chat messages and process emotes
   useEffect(() => {
     const fetchComments = async () => {
       try {
@@ -79,6 +39,81 @@ export default function ChatReplay({ chatReplayURL, youtubeId }: ChatReplayProps
         const response = await fetch(chatReplayURL)
         const data: ChatData = await response.json()
         console.log('[ChatReplay] Fetched', data.comments.length, 'comments');
+
+        // Process emotes from all comments
+        const emoteMap: Record<string, { type: 'twitch' | '7tv', id: string }> = {};
+        data.comments.forEach(comment => {
+          comment.message.fragments?.forEach(fragment => {
+            if (fragment.emoticon) {
+              emoteMap[fragment.text] = {
+                type: 'twitch',
+                id: fragment.emoticon.emoticon_id
+              };
+            }
+          });
+        });
+
+        // Fetch 7TV emotes
+        try {
+          const sevenTvResponse = await fetch('https://7tv.io/v4/gql', {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({
+              query: `
+                query($id: String!) {
+                  users {
+                    userByConnection(platform: TWITCH, platformId: $id) {
+                      style {
+                        activeEmoteSetId
+                      }
+                      emoteSets {
+                        id
+                        emotes {
+                          items {
+                            id 
+                            alias
+                          }
+                        }
+                      }
+                    } 
+                  }
+                }
+              `,
+              variables: {
+                id: SITE.TWITCH_USER_ID.toString()
+              }
+            })
+          });
+
+          const sevenTvData: SevenTvObject = await sevenTvResponse.json();
+          const activeEmoteSetId: string | undefined = sevenTvData.data.users.userByConnection.style.activeEmoteSetId
+
+          if (activeEmoteSetId) {
+            const activeEmoteSet: SevenTvEmoteSet | undefined = sevenTvData.data.users.userByConnection.emoteSets.find(obj => obj.id === activeEmoteSetId )
+            console.log('[ChatReplay] Active emote set:', activeEmoteSet)
+            console.log('[ChatReplay] Fetched 7TV emotes:', activeEmoteSet?.emotes?.items?.length || 0);
+  
+            // Add 7TV emotes to the emote map
+            if (activeEmoteSet) {
+              activeEmoteSet.emotes?.items?.forEach((emote: { id: string, alias: string }) => {
+                emoteMap[emote.alias] = {
+                  type: '7tv',
+                  id: emote.id
+                };
+              });   
+            } else {
+              console.error('[ChatReplay] Active emote set not found, skipping 7TV emotes');
+            }
+          } else {
+            console.error('[ChatReplay] Active emote set not found, skipping 7TV emotes');
+          }
+        } catch (error) {
+          console.error('[ChatReplay] Error fetching 7TV emotes:', error);
+        }
+
+        setEmoteData(emoteMap);
         setComments(data.comments.sort((a, b) => a.content_offset_seconds - b.content_offset_seconds))
       } catch (error) {
         console.error('[ChatReplay] Error fetching comments:', error)
@@ -86,7 +121,6 @@ export default function ChatReplay({ chatReplayURL, youtubeId }: ChatReplayProps
     }
     fetchComments()
   }, [chatReplayURL])
-
   // Initialize YouTube Player API
   useEffect(() => {
     if (!youtubeId) return;
@@ -276,7 +310,11 @@ export default function ChatReplay({ chatReplayURL, youtubeId }: ChatReplayProps
               ))}
               {comment.commenter.display_name}
             </span>{': '}
-            <span>{comment.message.body}</span>
+            <ChatMessage
+              fragments={comment.message.fragments || [{ text: comment.message.body, emoticon: null }]}
+              userColor={comment.message.user_color || 'inherit'}
+              emoteData={emoteData}
+            />
           </div>
         ))}
       </div>

--- a/src/components/chat-replay/SeventvEmote.tsx
+++ b/src/components/chat-replay/SeventvEmote.tsx
@@ -1,0 +1,17 @@
+import { type FC } from 'react';
+import type { SeventvEmoteProps } from './types';
+
+export const SeventvEmote: FC<SeventvEmoteProps> = ({ emoteId, text }) => {
+  // 7TV CDN URL for emotes
+  const emoteUrl = `https://cdn.7tv.app/emote/${emoteId}/1x.webp`;
+
+  return (
+    <img
+      src={emoteUrl}
+      alt={text}
+      title={text}
+      className="inline-block h-6 -my-1 w-auto"
+      loading="lazy"
+    />
+  );
+};

--- a/src/components/chat-replay/SeventvEmote.tsx
+++ b/src/components/chat-replay/SeventvEmote.tsx
@@ -1,17 +1,29 @@
-import { type FC } from 'react';
-import type { SeventvEmoteProps } from './types';
+import { type FC } from 'react'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+  TooltipProvider,
+} from '@/components/ui/tooltip'
+import type { SeventvEmoteProps } from './types'
 
 export const SeventvEmote: FC<SeventvEmoteProps> = ({ emoteId, text }) => {
   // 7TV CDN URL for emotes
-  const emoteUrl = `https://cdn.7tv.app/emote/${emoteId}/1x.webp`;
+  const emoteUrl = `https://cdn.7tv.app/emote/${emoteId}/1x.webp`
 
   return (
-    <img
-      src={emoteUrl}
-      alt={text}
-      title={text}
-      className="inline-block h-6 -my-1 w-auto"
-      loading="lazy"
-    />
-  );
-};
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger>
+          <img
+            src={emoteUrl}
+            alt={text}
+            className="-my-1 inline-block h-6 w-auto"
+            loading="lazy"
+          />
+        </TooltipTrigger>
+        <TooltipContent>{text}</TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  )
+}

--- a/src/components/chat-replay/TwitchEmote.tsx
+++ b/src/components/chat-replay/TwitchEmote.tsx
@@ -1,4 +1,10 @@
 import { type FC } from 'react';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+  TooltipProvider,
+} from '@/components/ui/tooltip'
 import type { TwitchEmoteProps } from './types'
 
 export const TwitchEmote: FC<TwitchEmoteProps> = ({ emoteId, text }) => {
@@ -6,12 +12,18 @@ export const TwitchEmote: FC<TwitchEmoteProps> = ({ emoteId, text }) => {
   const emoteUrl = `https://static-cdn.jtvnw.net/emoticons/v2/${emoteId}/default/dark/1.0`;
 
   return (
-    <img
-      src={emoteUrl}
-      alt={text}
-      title={text}
-      className="inline-block h-6 -my-1 w-auto"
-      loading="lazy"
-    />
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger>
+          <img
+            src={emoteUrl}
+            alt={text}
+            className="inline-block h-6 -my-1 w-auto"
+            loading="lazy"
+          />
+        </TooltipTrigger>
+        <TooltipContent>{text}</TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
   );
 };

--- a/src/components/chat-replay/TwitchEmote.tsx
+++ b/src/components/chat-replay/TwitchEmote.tsx
@@ -1,0 +1,17 @@
+import { type FC } from 'react';
+import type { TwitchEmoteProps } from './types'
+
+export const TwitchEmote: FC<TwitchEmoteProps> = ({ emoteId, text }) => {
+  // Twitch CDN URL for emotes
+  const emoteUrl = `https://static-cdn.jtvnw.net/emoticons/v2/${emoteId}/default/dark/1.0`;
+
+  return (
+    <img
+      src={emoteUrl}
+      alt={text}
+      title={text}
+      className="inline-block h-6 -my-1 w-auto"
+      loading="lazy"
+    />
+  );
+};

--- a/src/components/chat-replay/types.ts
+++ b/src/components/chat-replay/types.ts
@@ -1,0 +1,102 @@
+export interface ChatComment {
+  _id: string
+  created_at: string
+  content_offset_seconds: number
+  commenter: {
+    display_name: string
+    name: string
+    logo?: string
+  }
+  message: {
+    body: string
+    user_color?: string
+    user_badges?: Array<{
+      _id: string
+      version: string
+    }>
+    fragments: Array<{
+      text: string
+      emoticon: {
+        emoticon_id: string
+      } | null
+    }>
+  }
+}
+
+export interface ChatData {
+  comments: ChatComment[]
+  video: {
+    title: string
+    created_at: string
+    length: number
+  }
+}
+
+export interface ChatReplayProps {
+  chatReplayURL: string
+  youtubeId: string | undefined
+}
+
+export interface YouTubePlayer {
+  getCurrentTime(): number
+  getPlayerState(): number
+  destroy(): void
+}
+
+export interface YouTubeEvent {
+  target: YouTubePlayer
+  data: number
+}
+
+export interface SevenTvObject {
+  data: {
+    users: {
+      userByConnection: {
+        style: {
+          activeEmoteSetId: string | undefined
+        }
+        emoteSets: SevenTvEmoteSet[]
+      }
+    }
+  }
+}
+
+export interface SevenTvEmoteSet {
+  id: string
+  emotes: {
+    items: [
+      {
+        id: string
+        alias: string
+      },
+    ]
+  }
+}
+
+export interface BadgeProps {
+  badgeId: string;
+  version: string;
+}
+
+export interface TwitchEmoteProps {
+  emoteId: string
+  text: string
+}
+
+export interface SeventvEmoteProps {
+  emoteId: string
+  text: string
+}
+
+export interface MessageFragment {
+  text: string
+  emoticon: {
+    emoticon_id: string
+  } | null
+}
+
+export interface ChatMessageProps {
+  fragments: MessageFragment[]
+  userColor: string
+  emoteData: Record<string, { type: 'twitch' | '7tv'; id: string }>
+}

--- a/src/components/ui/tooltip.tsx
+++ b/src/components/ui/tooltip.tsx
@@ -1,0 +1,30 @@
+import * as React from "react"
+import * as TooltipPrimitive from "@radix-ui/react-tooltip"
+
+import { cn } from "@/lib/utils"
+
+const TooltipProvider = TooltipPrimitive.Provider
+
+const Tooltip = TooltipPrimitive.Root
+
+const TooltipTrigger = TooltipPrimitive.Trigger
+
+const TooltipContent = React.forwardRef<
+  React.ElementRef<typeof TooltipPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof TooltipPrimitive.Content>
+>(({ className, sideOffset = 4, ...props }, ref) => (
+  <TooltipPrimitive.Portal>
+    <TooltipPrimitive.Content
+      ref={ref}
+      sideOffset={sideOffset}
+      className={cn(
+        "z-50 overflow-hidden rounded-md bg-primary px-3 py-1.5 text-xs text-primary-foreground animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        className
+      )}
+      {...props}
+    />
+  </TooltipPrimitive.Portal>
+))
+TooltipContent.displayName = TooltipPrimitive.Content.displayName
+
+export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider }

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -1,3 +1,10 @@
+interface Badge {
+  id: string;
+  version: string;
+  imageUrl: string;
+  title: string;
+}
+
 export type Site = {
   TITLE: string
   DESCRIPTION: string
@@ -39,3 +46,21 @@ export const FOOTER_LINKS: Link[] = [
   { href: 'contact@ltwilson.tv', label: 'Email' },
   { href: '/rss.xml', label: 'RSS' },
 ]
+
+
+export const BADGES: Record<string, Badge> = {
+  moderator: {
+    id: 'moderator',
+    version: '1',
+    imageUrl: 'https://static-cdn.jtvnw.net/badges/v1/3267646d-33f0-4b17-b3df-f923a41db1d0/1',
+    title: 'Moderator',
+  },
+  vip: {
+    id: 'vip',
+    version: '1',
+    imageUrl: 'https://static-cdn.jtvnw.net/badges/v1/b817aba4-fad8-49e2-b88a-7cc744dfa6ec/1',
+    title: 'VIP',
+  },
+};
+
+export type BadgeId = keyof typeof BADGES;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -176,3 +176,14 @@
     }
   }
 }
+
+
+
+@layer base {
+  * {
+    @apply border-border outline-ring/50;
+  }
+  body {
+    @apply bg-background text-foreground;
+  }
+}


### PR DESCRIPTION
This adds the following additional functionality to the chat replay section of the VOD vault:

- Displays select chat badges next to usernames, such as moderator or VIP.
- Displays Twitch first-party emotes, like global emotes or subscriber emotes.
- Displays third-party emotes through 7TV.

Both badges and emotes display a tooltip to indicate what type of badge or what the name of the emote is.